### PR TITLE
readme: add missing "go" marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Example output:
 
 ## Example
 
-```
+```go
 f, err := os.Open(filepathArgument)
 log.PanicIf(err)
 


### PR DESCRIPTION
This enables proper syntax highlighting on GitHub.