### PR TITLE
exif-read-tool/main.go: exit 1 on panic

### DIFF
--- a/exif-read-tool/main.go
+++ b/exif-read-tool/main.go
@@ -49,6 +49,7 @@ func main() {
 		if state := recover(); state != nil {
 			err := log.Wrap(state.(error))
 			log.PrintErrorf(err, "Program error.")
+			os.Exit(1)
 		}
 	}()
 


### PR DESCRIPTION
This makes it easier to run exif-read-tool against a bunch of files and check for any errors.