### PR TITLE
Fix data race in LoadStandardTags

### DIFF
--- a/v3/go.mod
+++ b/v3/go.mod
@@ -7,7 +7,7 @@ go 1.12
 // replace github.com/dsoprea/go-utility/v2 => ../../go-utility/v2
 
 require (
-	github.com/dsoprea/go-logging v0.0.0-20200517223158-a10564966e9d
+	github.com/dsoprea/go-logging v0.0.0-20200710184922-b02d349568dd
 	github.com/dsoprea/go-utility/v2 v2.0.0-20200717064901-2fccff4aa15e
 	github.com/golang/geo v0.0.0-20200319012246-673a6f80352d
 	github.com/jessevdk/go-flags v1.4.0

--- a/v3/go.sum
+++ b/v3/go.sum
@@ -9,6 +9,8 @@ github.com/dsoprea/go-logging v0.0.0-20200502201358-170ff607885f h1:FonKAuW3PmNt
 github.com/dsoprea/go-logging v0.0.0-20200502201358-170ff607885f/go.mod h1:7I+3Pe2o/YSU88W0hWlm9S22W7XI1JFNJ86U0zPKMf8=
 github.com/dsoprea/go-logging v0.0.0-20200517223158-a10564966e9d h1:F/7L5wr/fP/SKeO5HuMlNEX9Ipyx2MbH2rV9G4zJRpk=
 github.com/dsoprea/go-logging v0.0.0-20200517223158-a10564966e9d/go.mod h1:7I+3Pe2o/YSU88W0hWlm9S22W7XI1JFNJ86U0zPKMf8=
+github.com/dsoprea/go-logging v0.0.0-20200710184922-b02d349568dd h1:l+vLbuxptsC6VQyQsfD7NnEC8BZuFpz45PgY+pH8YTg=
+github.com/dsoprea/go-logging v0.0.0-20200710184922-b02d349568dd/go.mod h1:7I+3Pe2o/YSU88W0hWlm9S22W7XI1JFNJ86U0zPKMf8=
 github.com/dsoprea/go-utility v0.0.0-20200711062821-fab8125e9bdf h1:/w4QxepU4AHh3AuO6/g8y/YIIHH5+aKP3Bj8sg5cqhU=
 github.com/dsoprea/go-utility v0.0.0-20200711062821-fab8125e9bdf/go.mod h1:95+K3z2L0mqsVYd6yveIv1lmtT3tcQQ3dVakPySffW8=
 github.com/dsoprea/go-utility/v2 v0.0.0-20200512094054-1abbbc781176 h1:CfXezFYb2STGOd1+n1HshvE191zVx+QX3A1nML5xxME=

--- a/v3/tags.go
+++ b/v3/tags.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/dsoprea/go-logging"
+	log "github.com/dsoprea/go-logging"
 	"gopkg.in/yaml.v2"
 
-	"github.com/dsoprea/go-exif/v3/common"
+	exifcommon "github.com/dsoprea/go-exif/v3/common"
 )
 
 const (
@@ -406,7 +406,9 @@ func LoadStandardTags(ti *TagIndex) (err error) {
 	}()
 
 	ti.tagsInit.Do(func() {
-
+		if len(ti.tagsByIfd) != 0 {
+			return
+		}
 		// Read static data.
 
 		encodedIfds := make(map[string][]encodedTag)


### PR DESCRIPTION
By loading the tags in a `sync.Once`.