### PR TITLE
set unitCount=1 for ThumbnailOffset

### DIFF
--- a/v3/ifd_builder_encode.go
+++ b/v3/ifd_builder_encode.go
@@ -241,6 +241,11 @@ func (ibe *IfdByteEncoder) encodeTagToBytes(ib *IfdBuilder, bt *BuilderTag, bw *
 			if remainder > 0 {
 				log.Panicf("tag (0x%04x) value of (%d) bytes not evenly divisible by type-size (%d)", bt.tagId, len_, typeSize)
 			}
+
+		}
+		if bt.tagId == ThumbnailOffsetTagId {
+			// The thumbnail offset is store as a long and its unit count must be 1
+			unitCount = 1
 		}
 
 		err = bw.WriteUint32(unitCount)


### PR DESCRIPTION
fix #70 

This pull request fixes a bug where certain tools (such as exiftool) raised warnings and failed to extract thumbnails properly when updating EXIF tags using this library. Upon investigation, setting unitCount for ThumbnailOffset to 1 resolves the issue.

Here's the code snippet I use to update EXIF tags:
```go
package main

import (
	"io"
	"os"

	jpegstructure "github.com/dsoprea/go-jpeg-image-structure/v2"
)

func main() {
	f, err := os.Open("./input.jpg")
	if err != nil {
		panic(err)
	}
	imageBytes, err := io.ReadAll(f)
	if err != nil {
		panic(err)
	}
	jmp := jpegstructure.NewJpegMediaParser()
	intfc, err := jmp.ParseBytes(imageBytes)
	if err != nil {
		panic(err)
	}
	sl := (intfc).(*jpegstructure.SegmentList)
	rootIb, err := sl.ConstructExifBuilder()
	if err != nil {
		panic(err)
	}
	err = sl.SetExif(rootIb)
	if err != nil {
		panic(err)
	}
	wf, err := os.Create("./result.jpg")
	if err != nil {
		panic(err)
	}
	err = sl.Write(wf)
	if err != nil {
		panic(err)
	}
}

```