### PR TITLE
Increase precision of GpsDegrees.Raw()

### DIFF
--- a/v3/gps.go
+++ b/v3/gps.go
@@ -77,14 +77,15 @@ func (d GpsDegrees) Decimal() float64 {
 	return decimal
 }
 
-// Raw returns a Rational struct that can be used to *write* coordinates. In
-// practice, the denominator are typically (1) in the original EXIF data, and,
-// that being the case, this will best preserve precision.
+// Raw returns a slice of Rationals that can be used to *write* coordinates. The
+// conversion uses a denominator of 1 for degrees and minutes and 1000 for
+// seconds. These denominators are not necessarily the same as the original
+// data, but they will provide a precision of about an inch at the equator.
 func (d GpsDegrees) Raw() []exifcommon.Rational {
 	return []exifcommon.Rational{
 		{Numerator: uint32(d.Degrees), Denominator: 1},
 		{Numerator: uint32(d.Minutes), Denominator: 1},
-		{Numerator: uint32(d.Seconds), Denominator: 1},
+		{Numerator: uint32(d.Seconds * 1000.0), Denominator: 1000},
 	}
 }
 


### PR DESCRIPTION
When using the method `Raw()` of `GpsDegrees` precision is lost due to arc-second rounding in Raw().

This PR tries to fix that by changing `Raw()` to always use 1000 as the denominator for arc seconds.

I have observed 100 and 1000 in the wild, so 1000 is a safe bet that should satisfy all consumer GNSS receivers.