### PR TITLE
Fix v3 TagExifA301SceneType decoder

### DIFF
--- a/v3/undefined/exif_A301_scene_type.go
+++ b/v3/undefined/exif_A301_scene_type.go
@@ -56,12 +56,12 @@ func (CodecExifA301SceneType) Decode(valueContext *exifcommon.ValueContext) (val
 		}
 	}()
 
-	valueContext.SetUndefinedValueType(exifcommon.TypeLong)
+	valueContext.SetUndefinedValueType(exifcommon.TypeByte)
 
-	valueLongs, err := valueContext.ReadLongs()
+	valueBytes, err := valueContext.ReadBytes()
 	log.PanicIf(err)
 
-	return TagExifA301SceneType(valueLongs[0]), nil
+	return TagExifA301SceneType(valueBytes[0]), nil
 }
 
 func init() {

--- a/v3/undefined/exif_A301_scene_type_test.go
+++ b/v3/undefined/exif_A301_scene_type_test.go
@@ -39,9 +39,9 @@ func TestCodecExifA301SceneType_Encode(t *testing.T) {
 }
 
 func TestCodecExifA301SceneType_Decode(t *testing.T) {
-	expectedUt := TagExifA301SceneType(0x1234)
+	expectedUt := TagExifA301SceneType(0x01)
 
-	encoded := []byte{0, 0, 0x12, 0x34}
+	encoded := []byte{0x01}
 
 	rawValueOffset := encoded
 


### PR DESCRIPTION
- Decoding the value as long gives scene type value 16777216 instead of 1 ("Directly photographed").